### PR TITLE
Update flashing-the-firmware.mdx to fix the ImpulseRC Driver location…

### DIFF
--- a/docs/setup/flashing-the-firmware.mdx
+++ b/docs/setup/flashing-the-firmware.mdx
@@ -17,7 +17,7 @@ This walk-through uses Windows, but it should also work on Linux or MacOS.
 On Windows, download and install the [STM32 Virtual COM Port Driver](https://www.st.com/en/development-tools/stsw-stm32102.html).
 
 :::caution[Driver issues]
-If there are issues connecting to the flight controller please download the [ImpulseRC Driver Fixer](https://impulserc.com/pages/downloads).
+If there are issues connecting to the flight controller please download the [ImpulseRC Driver Fixer](https://github.com/ImpulseRC/ImpulseRC_Driver_Fixer).
 
 <img src={DriverFixer} alt="DriverFixer" width="20%" />
 :::


### PR DESCRIPTION
… link

Due to ImpulseRC shutdown, the location of ImpulseRC driver has been rehosted for all on GitHub, updating the firmware updating documentation to reflect the new ImpulseRC driver location url.