### PR TITLE
Version 2.0.0 Docs - Update Flashing-the-firmware.md  Impulse RC driver location

### DIFF
--- a/versioned_docs/version-2.0.0/Wiki/Tutorial-Setup/Flashing-the-firmware.md
+++ b/versioned_docs/version-2.0.0/Wiki/Tutorial-Setup/Flashing-the-firmware.md
@@ -85,4 +85,4 @@ Rotorflight Configurator will display DFU - STM32 BOOTLOADER at the top of the p
 
 ![Flashing](./img/flash-7.png)
 
-If you still having problem connecting to the MCU, install the [**Impulse-RC Driver Fixer**](https://impulserc.com/pages/downloads).
+If you still having problem connecting to the MCU, install the [**Impulse-RC Driver Fixer**](https://github.com/ImpulseRC/ImpulseRC_Driver_Fixer).


### PR DESCRIPTION

Impulse driver fix now located in github location
https://github.com/ImpulseRC/ImpulseRC_Driver_Fixer

Docs 2.3, 2,2 and 2,1 alread updated and merged.