### PR TITLE
Update cspell config, add missing terms, update CI to run checks befo…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,20 @@ jobs:
           echo BASE_PATH=${{ steps.output.outputs.BASE_PATH }} >> .env
           echo ORG=${{ github.repository_owner }} >> .env
 
-      - name: Install dependencies & build
-        run: |
-          npm ci
-          npm run build
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run prettier:check:all
+
+      - name: Spellcheck
+        run: npm run spellcheck:all
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/README.md
+++ b/README.md
@@ -42,3 +42,16 @@ This will create a `/build` directory, which contains the complete website.
 ### Faster build
 
 Optionally you can provide a `FASTER=true` environment variable to use the new swc based build system, which is much faster than the default webpack based build system. More info in this [blog post](https://docusaurus.io/blog/releases/3.6#docusaurus-faster).
+
+## Adding missing terminology
+
+The project uses cspell to check spelling in documentation and source files. If
+cspell reports a valid Rotorflight term, product name, acronym, or other
+project-specific word as misspelled, add it to `project-words.txt`.
+
+Add one term per line, keep the list alphabetically sorted where practical, and
+prefer the exact casing used in the documentation. After updating the file, run:
+
+```
+npm run spellcheck:all
+```

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,16 @@
   "gitignoreRoot": ".",
   "useGitignore": true,
   "ignoreRegExpList": ["Urls", "Email"],
+  "import": [
+    "@cspell/dict-en-gb/cspell-ext.json",
+    "@cspell/dict-en_us/cspell-ext.json",
+    "@cspell/dict-typescript/cspell-ext.json",
+    "@cspell/dict-software-terms/cspell-ext.json",
+    "@cspell/dict-css/cspell-ext.json",
+    "@cspell/dict-html/cspell-ext.json",
+    "@cspell/dict-companies/cspell-ext.json",
+    "@cspell/dict-markdown/cspell-ext.json"
+  ],
   "dictionaryDefinitions": [
     {
       "name": "project-words",
@@ -11,15 +21,17 @@
       "addWords": true
     }
   ],
-  "language": "en",
+  "language": "en, en-US, en-GB",
   "dictionaries": [
     "project-words",
+    "en_US",
+    "en_gb",
     "css",
     "html",
-    "javascript",
     "typescript",
     "companies",
-    "softwareTerms"
+    "softwareTerms",
+    "markdown"
   ],
   "ignorePaths": [
     "node_modules",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,14 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@cspell/dict-companies": "^3.2.11",
+        "@cspell/dict-css": "^4.1.2",
+        "@cspell/dict-en_us": "^4.4.35",
+        "@cspell/dict-en-gb": "^5.0.29",
+        "@cspell/dict-html": "^4.0.15",
+        "@cspell/dict-markdown": "^2.0.17",
+        "@cspell/dict-software-terms": "^5.2.2",
+        "@cspell/dict-typescript": "^3.2.3",
         "@docusaurus/module-type-aliases": "^3.9.2",
         "@docusaurus/tsconfig": "^3.9.2",
         "@docusaurus/types": "^3.9.2",
@@ -2276,9 +2284,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-css": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
-      "integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.2.tgz",
+      "integrity": "sha512-+ylGoKdwZ2sVOCOnU2Eq5wDZx+RaVX3HoKyNHGGsFvhSw6IidQ6tH/mAPKBDofViHJoWCPNlklE0lTr6MDG3QA==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2326,9 +2334,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.31",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.31.tgz",
-      "integrity": "sha512-MdV6mbrSkyIqn9+6F5poCyHIPqWB3H/wlDL9LXfjgAxNFBdYRE767xJtIYunzUqhUiJHSJgZajEFdTtMDw441Q==",
+      "version": "4.4.35",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.35.tgz",
+      "integrity": "sha512-xWpxBCc/FzzMMo/A+0qwARVaIIhR0Ql8yhhv4rvsvg+GfQF+LG9yzg2GwTM5N2rjvzmM3nKuR9zxFZq2I6fJSg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2338,6 +2346,13 @@
       "integrity": "sha512-14Eu6QGqyksqOd4fYPuRb58lK1Va7FQK9XxFsRKnZU8LhL3N+kj7YKDW+7aIaAN/0WGEqslGP6lGbQzNti8Akw==",
       "dev": true,
       "license": "CC BY-SA 4.0"
+    },
+    "node_modules/@cspell/dict-en-gb": {
+      "version": "5.0.29",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-5.0.29.tgz",
+      "integrity": "sha512-r9gISbSufiJ1AVluQ2qROX6dBqF0sMSvOPWKKYsBKaaw5aBh0zy4+a6oVuXdaCgv7s79oizjHHc2BhiVaZ6nyw==",
+      "dev": true,
+      "license": "LGPL-3.0"
     },
     "node_modules/@cspell/dict-en-gb-mit": {
       "version": "3.1.20",
@@ -2489,13 +2504,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-markdown": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.16.tgz",
-      "integrity": "sha512-976RRqKv6cwhrxdFCQP2DdnBVB86BF57oQtPHy4Zbf4jF/i2Oy29MCrxirnOBalS1W6KQeto7NdfDXRAwkK4PQ==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.17.tgz",
+      "integrity": "sha512-H8bAxih6U8NOnSPL7R8My+tqjaB4tmnJTjERuz4zYqmf+cH+5xshX3UVgKlwWFcyjsYfv/zEDuRdMctQv1q6HQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@cspell/dict-css": "^4.1.1",
+        "@cspell/dict-css": "^4.1.2",
         "@cspell/dict-html": "^4.0.15",
         "@cspell/dict-html-symbol-entities": "^4.0.5",
         "@cspell/dict-typescript": "^3.2.3"
@@ -2589,9 +2604,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.0.tgz",
-      "integrity": "sha512-jyucc8KKxH5ClC4FPICISgcKAZU7UwgFdPkuuuK5nYIw0+l1umnUSn9IKCcOaurvXujvVP6mBfclXpUtmT6Vrw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.2.tgz",
+      "integrity": "sha512-0CaYd6TAsKtEoA7tNswm1iptEblTzEe3UG8beG2cpSTHk7afWIVMtJLgXDv0f/Li67Lf3Z1Jf3JeXR7GsJ2TRw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,14 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@cspell/dict-companies": "^3.2.11",
+    "@cspell/dict-css": "^4.1.2",
+    "@cspell/dict-en_us": "^4.4.35",
+    "@cspell/dict-en-gb": "^5.0.29",
+    "@cspell/dict-html": "^4.0.15",
+    "@cspell/dict-markdown": "^2.0.17",
+    "@cspell/dict-software-terms": "^5.2.2",
+    "@cspell/dict-typescript": "^3.2.3",
     "@docusaurus/module-type-aliases": "^3.9.2",
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.9.2",

--- a/project-words.txt
+++ b/project-words.txt
@@ -53,11 +53,14 @@ sunnysky
 rateprofile
 acro
 dshot
+dshotprog
+escprog
 feedforward
 piro
 tock
 precomp
 precompensation
+PLLP
 evenodd
 dterm
 cycletime
@@ -68,6 +71,8 @@ deadband
 datasheet
 ccpm
 spoolup
+spooldown
+handback
 brushless
 molex
 pico
@@ -95,6 +100,8 @@ txtail
 calib
 bustype
 serialrx
+serialpassthrough
+gpspassthrough
 halfduplex
 autoreset
 vrefint
@@ -105,6 +112,7 @@ vbux
 bidir
 bitbang
 vbat
+Vref
 ibat
 nmea
 sbas
@@ -112,8 +120,10 @@ mavlink
 ledstrip
 sdcard
 sdio
+SPLC
 displayport
 rxfail
+rxtx
 vbus
 ibata
 vfas
@@ -131,6 +141,7 @@ hysteresis
 tocs
 rpmfilter
 nogyro
+gyroregisters
 carb
 feedforwards
 bldc
@@ -161,6 +172,7 @@ erpm
 outrunner
 zadig
 telem
+tele
 xattr
 nand
 cutoff
@@ -193,6 +205,7 @@ Kafuter
 rfsuite
 Shmuley
 aetrc
+AETR
 unsc
 customise
 autorotations
@@ -219,3 +232,21 @@ neswud
 ptch
 gspd
 Liang
+Kira
+centidegrees
+centivolts
+GHST
+kbps
+smartfuel
+FLVSS
+ADXL
+SBEC
+rescan
+ULSLXO
+Vcel
+Verif
+bandletter
+bandname
+vtxtable
+OPENYGE
+setpoints

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -39,7 +39,7 @@ const sidebars: SidebarsConfig = {
           items: [
             "controllers/goosky/f701",
             "controllers/goosky/f4mini",
-            "controllers/goosky/s2-tune"
+            "controllers/goosky/s2-tune",
           ],
         },
         "controllers/matek_heli",


### PR DESCRIPTION
…re build

This update is due to contributors commiting missspelled words and code into the repo. The dictionaries have been extened to support en-US and en-GB, the CI step has been broken down to install, the run checks and finally build to make sure we don't get missspelled terms/code into prod.
The readme has been updated with instruction on how to proceed with adding new terminology, the AGENTS file already has one.