### PR TITLE
Added note about ensuring main battery is connected for AM32Config

### DIFF
--- a/docs/controllers/goosky/s2-tune.mdx
+++ b/docs/controllers/goosky/s2-tune.mdx
@@ -76,6 +76,7 @@ Follow this update procedure carefully and completely. A failed flash can brick 
 6. Click on *Connect* in the upper right corner
 7. Click on *Read*. The *AM32 Configurator* will now show various ESC settings, as well as some new buttons.\
    ![Goosky F4-mini](../img/s2-esc-am32-configurator.png)
+   Note: If you recieve an error similar to "error: ACK_D_GENERAL_ERROR" - please ensure you have also connected the Goosky S2 Battery to power the ESC
 8. Click *Flash firmware*
 9. Go to the *Local* tab
 10. Select *Ignore current mcu layout* if you flash the ESC for the first time


### PR DESCRIPTION
People new to AM32 flashing, following the guide, will get stuck at the step to READ the values if they have not connected the Goosky S2 battery to power the ESC.  

The USB connected will be enough to connect and initilise the connection, but not enough to "Read" the values, so it can be confusing as they have a connection but start to get  an error: ACK_D_GENERAL_ERROR etc

Please feel free to adjust the content as you see fit , i jsut thought a small note about connecting the battery will reduce support questions on the AM32 process.